### PR TITLE
Remove buffers `noAssert` argument

### DIFF
--- a/lib/qlobber-fsq.js
+++ b/lib/qlobber-fsq.js
@@ -1662,7 +1662,7 @@ function QlobberFSQ(options)
                     {
                         var start = i * element_size,
                             end = start + element_size,
-                            len = buf.readUInt16LE(end - 2, true);
+                            len = buf.readUInt16LE(end - 2);
 
                         if (len === 0)
                         {
@@ -1676,7 +1676,7 @@ function QlobberFSQ(options)
                         {
                             if (info)
                             {
-                                info.size = buf.readUInt32LE(end - 6, true);
+                                info.size = buf.readUInt32LE(end - 6);
 
                                 if ((info.size <= element_size - 6 - len) &&
                                     !info.single)
@@ -2291,7 +2291,7 @@ QlobberFSQ.prototype.publish = function (topic, payload, options, cb)
         }
 
         element.copy(b);
-        b.writeUInt32LE(count, element_size, true);
+        b.writeUInt32LE(count, element_size);
 
         commit(disruptor.prevClaimStart, disruptor.prevClaimEnd);
     }
@@ -2361,7 +2361,7 @@ QlobberFSQ.prototype.publish = function (topic, payload, options, cb)
         }
         else
         {
-            element.writeUInt16LE(start, element_size + 4, true);
+            element.writeUInt16LE(start, element_size + 4);
 
             stream = new WriteStream(staging_fname, write_options);
 


### PR DESCRIPTION
Support for the `noAssert` argument dropped in the upcoming Node.js
v.10. This removes the argument to make sure everything works as it
should.

Refs: https://github.com/nodejs/node/pull/18395